### PR TITLE
Add concurrent download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,10 @@ Once installed, You have to authenticate to Google Music via the `google-music-a
 
 .. code::
 
-    # Usage google-music-auth [path_to_oauth_cred_file=~/oauth]
+    # Usage google-music-auth [path_to_oauth_cred_file=~/.gmusicdownloader/creds]
 
 
-If first parameter is not defined, the script will try to store/load your oauth credentials through the `~/oauth` file.
+If first parameter is not defined, the script will try to store/load your oauth credentials through the `~/.gmusicdownloader/creds` file.
 
 Then follow prompted instructions.
 
@@ -78,7 +78,7 @@ This program will download all your uploaded musics from Google Music to a given
         --directory DIRECTORY, -d DIRECTORY
                             Music Folder to download to (default: .)
         --oauth OAUTH, -a OAUTH
-                            Path to oauth file (default: ~/oauth)
+                            Path to oauth file (default: ~/.gmusicdownloader/creds)
         --device_id DEVICE_ID, -i DEVICE_ID
                             Device identification (should be an uppercase MAC
                             address) (default: <current eth0 MAC address>)

--- a/google_music_manager_downloader/download.py
+++ b/google_music_manager_downloader/download.py
@@ -1,51 +1,88 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import sys
+import argparse
+import concurrent.futures
 import logging
 import netifaces
-import argparse
 import os
+import sys
+
+from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 from gmusicapi import Musicmanager
+from pathlib import Path
+from typing import Callable
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
+handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(handler)
 
 __DEFAULT_IFACE__ = netifaces.gateways()['default'][netifaces.AF_INET][1]
 __DEFAULT_MAC__ = netifaces.ifaddresses(__DEFAULT_IFACE__)[netifaces.AF_LINK][0]['addr'].upper()
+__DEFAULT_CREDS_DIR__ = os.path.join(os.environ['HOME'], '.gmusicdownloader')
+__DEFAULT_CREDS__ = os.path.join(__DEFAULT_CREDS_DIR__, 'creds')
+if not Path(__DEFAULT_CREDS_DIR__).exists():
+    logger.debug(f"Creating {__DEFAULT_CREDS_DIR__}")
+    os.makedirs(__DEFAULT_CREDS_DIR__)
+if not Path(__DEFAULT_CREDS__).exists():
+    logger.debug(f"Creating {__DEFAULT_CREDS__}")
+    open(__DEFAULT_CREDS__, 'w').close()
 
 
 def download(
-    directory: str = ".",
-    oauth: str = os.environ['HOME'] + "/oauth",
+    base_dir: str = ".",
+    creds: str = __DEFAULT_CREDS__,
     device_id: str = __DEFAULT_MAC__
 ) -> None:
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.DEBUG)
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-    logger.info("Init Daemon - Press Ctrl+C to quit")
     api = Musicmanager()
-    if not api.login(oauth, device_id):
-        print("Error with oauth credentials")
+    if not api.login(creds, device_id):
+        logger.error("Error with oauth credentials")
         sys.exit(1)
 
-    for song in api.get_uploaded_songs():
-        folder_path = os.path.join(directory, song['album_artist'], song['album'])
-        file_path = os.path.join(
-            folder_path,
-            '%d - %s.mp3' % (
-                song['track_number'],
-                song['title'].replace('/', '_').replace('?', '_')
-            )
-        )
-        file_path = file_path.encode('utf8')
-        folder_path = folder_path.encode('utf8')
-        if not os.path.exists(file_path):
-            filename, audio = api.download_song(song['id'])
-            if not os.path.exists(folder_path):
-                os.makedirs(folder_path)
-            with open(file_path, 'wb') as f:
-                f.write(audio)
+    Song = namedtuple('Song', ['artist', 'album', 'track', 'title', 'id'])
+
+    def _download(song: Song, downloader: Callable) -> None:
+        logger.debug(f"Downloading song '{song.title}'")
+        f, audio = downloader(song.id)
+
+        folder = os.path.join(base_dir, song.artist, song.album)
+        if not os.path.exists(folder):
+            logger.debug(f"Creating folder '{folder}'")
+            os.makedirs(folder)
+        file = os.path.join(folder, f'{song.track}-{song.title}.mp3')
+        with open(file, 'wb') as f:
+            logger.debug(f"Writing file '{file}'")
+            f.write(audio)
+
+    songs = api.get_uploaded_songs()
+    n = len(songs)
+    logger.debug(f"Downloading '{n}' to folder '{base_dir}'")
+    future_to_song = {}
+    with ThreadPoolExecutor() as executor:
+        for song in songs:
+            artist = song['album_artist']
+            album = song['album']
+            track = song['track_number']
+            title = song['title'].replace('/', '_').replace('?', '_')
+            iden = song['id']
+            s = Song(artist=artist, album=album, track=track, title=title, id=iden)
+            future = executor.submit(_download, song=s, downloader=api.download_song)
+            future_to_song[future] = s
+
+        succeeded = 0
+        failed = 0
+        for future in concurrent.futures.as_completed(future_to_song):
+            s = future_to_song[future]
+            if future.exception():
+                logger.warning(f"Failed to download song '{s.title}' because '{future.exception()}'")
+                failed += 1
+                continue
+            succeeded += 1
+        logger.debug(f"Completed. Total {n} succeded {succeeded} failed {failed}")
 
 
 def main():
@@ -54,8 +91,8 @@ def main():
     parser.add_argument(
         "--oauth",
         '-a',
-        default=os.environ['HOME'] + '/oauth',
-        help="Path to oauth file (default: ~/oauth)"
+        default=__DEFAULT_CREDS__,
+        help="Path to oauth file (default: ~/.gmusicdownloader/creds)"
     )
     parser.add_argument(
         "--device_id",
@@ -64,7 +101,9 @@ def main():
         help="Device identification (should be an uppercase MAC address) (default: <current eth0 MAC address>)"
     )
     args = parser.parse_args()
-    download(args.directory, oauth=args.oauth, device_id=args.device_id)
+
+    logger.info("Downloading. Press Ctrl+C to quit")
+    download(args.directory, creds=args.oauth, device_id=args.device_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch adds concurrent download support as the sequential download is slow for large collections.
Also the following additional changes have been made as good practice:
a) Moved the default store for credentials to a private hidden folder
b) Improved log comments